### PR TITLE
Add unit test for `create_spark_session`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 - Utility functions and their unit tests.
 - Matrix A* functions and their unit tests.
 - Match score functions and their unit tests.
-- Unit test for `cartesian_join_dataframes` in `tests/utils/utils.py`.
+- Unit test for `cartesian_join_dataframes` in `tests/utils/test_utils.py`.
 - Unit test for `get_deltas` in `tests/indicator_matrix/test_indicator_matrix.py`.
 
 ### Changed
@@ -21,6 +21,7 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 - Dependabot updates including:
   - In GitHub Actions, bump actions/checkout from v4 to v5.
   - In GitHub Actions, bump actions/setup-python from v5 to v6.
+- Function `create_spark_session` in `scalelink/utils/utils.py`, to make it less verbose.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 - Matrix A* functions and their unit tests.
 - Match score functions and their unit tests.
 - Unit test for `cartesian_join_dataframes` in `tests/utils/test_utils.py`.
+- Unit test for `create_spark_session` in `tests/utils/test_utils_create_spark_session.py`.
 - Unit test for `get_deltas` in `tests/indicator_matrix/test_indicator_matrix.py`.
 
 ### Changed

--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from pyspark.sql import SparkSession
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def spark():
     """
     Sets up the Spark session by using a fixture decorator.

--- a/conftest.py
+++ b/conftest.py
@@ -14,12 +14,14 @@ def spark():
     """
     Sets up the Spark session by using a fixture decorator.
     """
-    return (
+    spark_session = (
         SparkSession.builder.appName("Unit testing")
         .config("spark.dynamicAllocation.enabled", "true")
         .config("spark.dynamicAllocation.maxExecutors", 30)
         .getOrCreate()
     )
+    yield spark_session
+    spark_session.stop()
 
 
 @pytest.fixture(scope="function")

--- a/scalelink/utils/utils.py
+++ b/scalelink/utils/utils.py
@@ -132,12 +132,14 @@ def create_spark_session(spark_session_name, spark_session_size):
     session_configs = {
         "s": {
             "spark.executor.memory": "1g",
+            "spark.yarn.executor.memoryOverhead": "1g",
             "spark.executor.cores": 1,
             "spark.dynamicAllocation.maxExecutors": 3,
             "spark.sql.shuffle.partitions": 12,
         },
         "m": {
             "spark.executor.memory": "6g",
+            "spark.yarn.executor.memoryOverhead": "1g",
             "spark.executor.cores": 3,
             "spark.dynamicAllocation.maxExecutors": 3,
             "spark.sql.shuffle.partitions": 18,

--- a/scalelink/utils/utils.py
+++ b/scalelink/utils/utils.py
@@ -124,96 +124,57 @@ def create_spark_session(spark_session_name, spark_session_size):
             extra-large (xl).
 
     Dependencies:
-        pyspark
-        pyspark.sql
+        SparkSession from pyspark.sql
 
     Returns:
         A Spark session of the specified size.
     """
-    session_sizes = {
+    session_configs = {
         "s": {
-            "executor_memory": "1g",
-            "executor_cores": 1,
-            "max_executors": 3,
-            "shuffle_partitions": 12,
+            "spark.executor.memory": "1g",
+            "spark.executor.cores": 1,
+            "spark.dynamicAllocation.maxExecutors": 3,
+            "spark.sql.shuffle.partitions": 12,
         },
         "m": {
-            "executor_memory": "6g",
-            "executor_cores": 3,
-            "max_executors": 3,
-            "shuffle_partitions": 18,
+            "spark.executor.memory": "6g",
+            "spark.executor.cores": 3,
+            "spark.dynamicAllocation.maxExecutors": 3,
+            "spark.sql.shuffle.partitions": 18,
         },
         "l": {
-            "executor_memory": "10g",
-            "memory_overhead": "1g",
-            "executor_cores": 5,
-            "max_executors": 5,
-            "shuffle_partitions": 200,
+            "spark.executor.memory": "10g",
+            "spark.yarn.executor.memoryOverhead": "1g",
+            "spark.executor.cores": 5,
+            "spark.dynamicAllocation.maxExecutors": 5,
+            "spark.sql.shuffle.partitions": 200,
         },
         "xl": {
-            "executor_memory": "20g",
-            "memory_overhead": "2g",
-            "executor_cores": 5,
-            "max_executors": 12,
-            "shuffle_partitions": 240,
+            "spark.executor.memory": "20g",
+            "spark.yarn.executor.memoryOverhead": "2g",
+            "spark.executor.cores": 5,
+            "spark.dynamicAllocation.maxExecutors": 12,
+            "spark.sql.shuffle.partitions": 240,
         },
     }
 
-    if spark_session_size in ["s", "m"]:
-        spark = (
-            SparkSession.builder.appName(spark_session_name)
-            .config(
-                "spark.executor.memory",
-                session_sizes[spark_session_size]["executor_memory"],
-            )
-            .config(
-                "spark.executor.cores",
-                session_sizes[spark_session_size]["executor_cores"],
-            )
-            .config("spark.dynamicAllocation.enabled", "true")
-            .config(
-                "spark.dynamicAllocation.maxExecutors",
-                session_sizes[spark_session_size]["max_executors"],
-            )
-            .config(
-                "spark.sql.shuffle.partitions",
-                session_sizes[spark_session_size]["shuffle_partitions"],
-            )
-            .config("spark.shuffle.service.enabled", "true")
-            .config("spark.ui.showConsoleProgress", "false")
-            .enableHiveSupport()
-            .getOrCreate()
-        )
+    if spark_session_size not in session_configs.keys():
+      raise ValueError(
+        f"{spark_session_size} is not a valid SparkSession, use one of [{", ".join(list(session_configs.keys()))}]
+      )
 
-    if spark_session_size in ["l", "xl"]:
-        spark = (
-            SparkSession.builder.appName(spark_session_name)
-            .config(
-                "spark.executor.memory",
-                session_sizes[spark_session_size]["executor_memory"],
-            )
-            .config(
-                "spark.yarn.executor.memoryOverhead",
-                session_sizes[spark_session_size]["memory_overhead"],
-            )
-            .config(
-                "spark.executor.cores",
-                session_sizes[spark_session_size]["executor_cores"],
-            )
-            .config("spark.dynamicAllocation.enabled", "true")
-            .config(
-                "spark.dynamicAllocation.maxExecutors",
-                session_sizes[spark_session_size]["max_executors"],
-            )
-            .config(
-                "spark.sql.shuffle.partitions",
-                session_sizes[spark_session_size]["shuffle_partitions"],
-            )
-            .config("spark.shuffle.service.enabled", "true")
-            .config("spark.ui.showConsoleProgress", "false")
-            .enableHiveSupport()
-            .getOrCreate()
-        )
+    session_config = session_configs[spark_session_size]
+    spark_builder = (
+      SparkSession.builder.appName(spark_session_name)
+      .config("spark.shuffle.service.enabled", "true")
+      .config("spark.ui.showConsoleProgress", "false")
+      .enableHiveSupport()
+    )
+
+    for k, v in session_size.items():
+      spark_builder.config(k, v)
+
+    spark = spark_builder.getOrCreate()
 
     return spark
 

--- a/scalelink/utils/utils.py
+++ b/scalelink/utils/utils.py
@@ -159,20 +159,20 @@ def create_spark_session(spark_session_name, spark_session_size):
     }
 
     if spark_session_size not in session_configs.keys():
-      raise ValueError(
-        f"{spark_session_size} is not a valid SparkSession, use one of [{", ".join(list(session_configs.keys()))}]
-      )
+        raise ValueError(
+            f"{spark_session_size} is not a valid SparkSession, use one of [{', '.join(list(session_configs.keys()))}]"
+        )
 
     session_config = session_configs[spark_session_size]
     spark_builder = (
-      SparkSession.builder.appName(spark_session_name)
-      .config("spark.shuffle.service.enabled", "true")
-      .config("spark.ui.showConsoleProgress", "false")
-      .enableHiveSupport()
+        SparkSession.builder.appName(spark_session_name)
+        .config("spark.shuffle.service.enabled", "true")
+        .config("spark.ui.showConsoleProgress", "false")
+        .enableHiveSupport()
     )
 
-    for k, v in session_size.items():
-      spark_builder.config(k, v)
+    for k, v in session_config.items():
+        spark_builder.config(k, v)
 
     spark = spark_builder.getOrCreate()
 

--- a/tests/indicator_matrix/test_indicator_matrix.py
+++ b/tests/indicator_matrix/test_indicator_matrix.py
@@ -328,7 +328,7 @@ def test_get_deltas(
     agreement_states_output_df,
 ):
     """
-    Tests that get_deltas give the correct output when supplied with appropriate inputs.
+    Tests that get_deltas gives the correct output when supplied with appropriate inputs.
     """
     # Arrange
     test_input_df = sorensen_dice_input_df

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -36,8 +36,8 @@ from scalelink.utils import utils as ut
 
 def test_define_binary_agreement_vars():
     """
-    Tests that define_binary_agreement_vars gives the gives the correct output
-    when supplied with appropriate inputs.
+    Tests that define_binary_agreement_vars gives the correct output when
+    supplied with appropriate inputs.
     """
     # Arrange
     test_input = {"fn": [0.4, 0.7, 0.9], "sn": [0.75, 0.9], "sex": None, "dob": None}
@@ -53,8 +53,8 @@ def test_define_binary_agreement_vars():
 
 def test_cartesian_join_dataframes(spark, spark_mock):
     """
-    Tests that cartesian_join_dataframes() gives the gives the correct output
-    when supplied with appropriate inputs.
+    Tests that cartesian_join_dataframes() gives the correct output when supplied
+    with appropriate inputs.
     """
     # Arrange
     mock_path = Mock()
@@ -105,8 +105,8 @@ def test_create_spark_session():
 
 def test_define_K():
     """
-    Tests that define_K() gives the gives the gives the correct output when
-    supplied with appropriate inputs.
+    Tests that define_K() gives the correct output when supplied with appropriate
+    inputs.
     """
     # Arrange
     test_input = {"fn": 2, "sn": 4, "sex": 2}
@@ -122,8 +122,8 @@ def test_define_K():
 
 def test_define_kj():
     """
-    Tests that define_kj() gives the gives the correct output when supplied with
-    appropriate inputs.
+    Tests that define_kj() gives the correct output when supplied with appropriate
+    inputs.
     """
     # Arrange
     test_input = {
@@ -143,8 +143,8 @@ def test_define_kj():
 
 def test_define_p():
     """
-    Tests that define_p() gives the gives the correct output when provided with
-    appropriate inputs.
+    Tests that define_p() gives the correct output when provided with appropriate
+    inputs.
     """
     # Arrange
     test_input_1 = ["fn", "sn", "sex"]
@@ -164,8 +164,8 @@ def test_define_p():
 
 def test_define_partial_agreement_vars():
     """
-    Tests that define_partial_agreement_vars() gives the gives the correct
-    output when provided with appropriate inputs.
+    Tests that define_partial_agreement_vars() gives the correct output when
+    provided with appropriate inputs.
     """
     # Arrange
     test_input = {"fn": [0.4, 0.7, 0.9], "sn": [0.75, 0.9], "sex": None, "dob": None}
@@ -181,8 +181,8 @@ def test_define_partial_agreement_vars():
 
 def test_format_cutpoints():
     """
-    Tests that format_cutpoints() gives the gives the correct output when
-    provided with appropriate inputs.
+    Tests that format_cutpoints() gives the correct output when provided with
+    appropriate inputs.
 
     Dependencies:
       configparser as cp
@@ -228,8 +228,8 @@ def test_get_input_variables():
 
 def test_get_s(spark):
     """
-    Tests that get_s() gives the gives the correct output when provided with
-    appropriate inputs.
+    Tests that get_s() gives the correct output when provided with appropriate
+    inputs.
     """
     # Arrange
     test_input_df = spark.createDataFrame(

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -27,7 +27,6 @@ import os
 from unittest.mock import Mock, patch
 
 import chispa as ch
-import pytest
 
 from scalelink.utils import utils as ut
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -5,8 +5,6 @@ Methods:
 
   cartesian_join_dataframes
 
-  create_spark_session - test shell only, currently
-
   define_K
 
   define_kj
@@ -98,11 +96,6 @@ def test_cartesian_join_dataframes(spark, spark_mock):
     ch.assert_df_equality(df1=test_output, df2=expected_output, ignore_row_order=True)
 
 
-@pytest.mark.skip(reason="test shell")
-def test_create_spark_session():
-    pass
-
-
 def test_define_K():
     """
     Tests that define_K() gives the correct output when supplied with appropriate
@@ -113,10 +106,10 @@ def test_define_K():
 
     expected_output = 8
 
-    # Assert
+    # Act
     test_output = ut.define_K(kj=test_input)
 
-    # Act
+    # Assert
     assert test_output == expected_output
 
 

--- a/tests/utils/test_utils_create_spark_session.py
+++ b/tests/utils/test_utils_create_spark_session.py
@@ -1,0 +1,88 @@
+"""
+Utility function unit test.
+
+Methods:
+  create_spark_session
+
+This utility function requires no other Spark sessions to be concurrently
+running in the environment. Else, a new Spark session will not be made,
+expected_outputs will reflect the prior Spark session and the test will fail.
+Some of the other utility function tests use the spark fixture, which has
+modular scope. Hence, this test has to be held in a separate module from them.
+"""
+
+from scalelink.utils import utils as ut
+
+
+def test_create_spark_session():
+    """
+    Tests that create_spark_session() gives the correct output when supplied
+    with appropriate inputs.
+
+    Dependencies:
+      No other Spark sessions currently running in the environment.
+    """
+    # Arrange
+    test_inputs = {
+        1: ["test_1", "s"],
+        2: ["test_2", "m"],
+        3: ["test_3", "l"],
+        4: ["test_4", "xl"],
+    }
+
+    expected_outputs = {
+        "s": {
+            "spark.executor.memory": "1g",
+            "spark.yarn.executor.memoryOverhead": "1g",
+            "spark.executor.cores": "1",
+            "spark.dynamicAllocation.maxExecutors": "3",
+            "spark.sql.shuffle.partitions": "12",
+            "spark.shuffle.service.enabled": "true",
+            "spark.ui.showConsoleProgress": "false",
+        },
+        "m": {
+            "spark.executor.memory": "6g",
+            "spark.yarn.executor.memoryOverhead": "1g",
+            "spark.executor.cores": "3",
+            "spark.dynamicAllocation.maxExecutors": "3",
+            "spark.sql.shuffle.partitions": "18",
+            "spark.shuffle.service.enabled": "true",
+            "spark.ui.showConsoleProgress": "false",
+        },
+        "l": {
+            "spark.executor.memory": "10g",
+            "spark.yarn.executor.memoryOverhead": "1g",
+            "spark.executor.cores": "5",
+            "spark.dynamicAllocation.maxExecutors": "5",
+            "spark.sql.shuffle.partitions": "200",
+            "spark.shuffle.service.enabled": "true",
+            "spark.ui.showConsoleProgress": "false",
+        },
+        "xl": {
+            "spark.executor.memory": "20g",
+            "spark.yarn.executor.memoryOverhead": "2g",
+            "spark.executor.cores": "5",
+            "spark.dynamicAllocation.maxExecutors": "12",
+            "spark.sql.shuffle.partitions": "240",
+            "spark.shuffle.service.enabled": "true",
+            "spark.ui.showConsoleProgress": "false",
+        },
+    }
+
+    # Act
+    test_outputs = {}
+    for count, i in enumerate(test_inputs, 1):
+        spark_session = ut.create_spark_session(
+            spark_session_name=test_inputs[count][0],
+            spark_session_size=test_inputs[count][1],
+        )
+        test_output = dict(spark_session.sparkContext.getConf().getAll())
+        test_outputs.update({test_inputs[count][1]: test_output})
+        spark_session.stop()
+
+    # Assert
+    for count, size in enumerate(expected_outputs.keys()):
+        for key in expected_outputs[size].keys():
+            assert (
+                expected_outputs[size][key] == test_outputs[size][key]
+            ), f"for {size}:\n expected_output {key} is {expected_outputs[size][key]}\n test_output {key} is {test_outputs[size][key]}"


### PR DESCRIPTION
## Description

Add unit test for `create_spark_session`.

This was a little involved as it turns out there can only be one Spark session running at a time in an environment. Hence, the unit test would run fine on its own but would fail if run with other tests that use the `spark` fixture in `conftest.py`. To get around this, I:

- Updated the `spark` fixture to give it clean-up functionality, so that it stops the Spark session once its scope ends.
- Changed the scope of the `spark` fixture to module, so that it is broken down after each test module/script.
- Moved the unit test for `create_spark_session` to its own script, so that it is in its own module (i.e. without the `spark` fixture being called by anything else).

Another valid way to get around this would be to:

- Move the unit test for `create_spark_session` to its own script and place this at the head of the `tests` folder, i.e. `scalelink/tests/test_create_spark_session.py` or similar.
- Move the `conftest.py` script to the same location.
- Keep the scope of the `spark` fixture as session.

This should work, as tests can only access fixtures that are one or more directory layers above them. So, arranging the directory in this way (with the `create_spark_session` unit test and `conftest.py` at the same level) would prevent the interaction, despite the fixture scope being session. This seemed to me to be less readable (i.e. the test would no longer be in the `utils` folder where one would expect it). However, it might be a better fix in future if the unit tests start taking a long time to run as it would mean the spark fixture is only made and broken down once per test session rather than once per module.

closes #30 #33 

## Type of change

*You can delete options that are not relevant.*

- [ ] Bug fix - *non-breaking change*
- [x] New feature - *non-breaking change*
- [ ] Breaking change - *backwards incompatible change, changes expected behaviour*
- [x] Non-user facing change, structural change, dev functionality, docs ...

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code appropriately, focusing on explaining my design decisions (explain why, not how).
- [x] I have made corresponding changes to the documentation (comments, docstring, etc.. )
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the change log.

<br>

#  Peer review
Any new code includes all the following:

- **Documentation**: docstrings, comments have been added/ updated.
- **Style guidelines**: New code conforms to the project's contribution guidelines.
- **Functionality**: The code works as expected, handles expected edge cases and exceptions are handled appropriately.
- **Complexity**: The code is not overly complex, logic has been split into appropriately sized functions, etc..
- **Test coverage**: Unit tests cover essential functions for a reasonable range of inputs and conditions. Added and existing tests pass on my machine.

### Review comments
Suggestions should be tailored to the code that you are reviewing. Provide context.
Be critical and clear, but not mean. Ask questions and set actions.
<details><summary>These might include:</summary>

- bugs that need fixing (does it work as expected? and does it work with other code
  that it is likely to interact with?)
- alternative methods (could it be written more efficiently or with more clarity?)
- documentation improvements (does the documentation reflect how the code actually works?)
- additional tests that should be implemented
  - Do the tests effectively assure that it
  works correctly? Are there additional edge cases/ negative tests to be considered?
- code style improvements (could the code be written more clearly?)
</details>
<br>

*Further reading: [code review best practices](https://best-practice-and-impact.github.io/qa-of-code-guidance/peer_review.html)*
